### PR TITLE
Support for stable rust as per #318

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
+curve25519-dalek = { version = "2", default-features = false, features = ["u64_backend", "serde"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
@@ -29,7 +29,7 @@ serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "2", default-features = false }
-clear_on_drop = { version = "=0.2.4", default-features = false }
+clear_on_drop = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 hex = "0.3"
@@ -38,10 +38,13 @@ bincode = "1"
 rand_chacha = "0.2"
 
 [features]
-default = ["std", "avx2_backend"]
+default = ["std"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
-# yoloproofs = []
-std = ["rand", "rand/std", "thiserror"]
+yoloproofs = []
+std = ["rand", "rand/std", "thiserror", "curve25519-dalek/std"]
+nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
+docs = ["nightly"]
+
 
 [[test]]
 name = "range_proof"
@@ -53,6 +56,7 @@ required-features = ["yoloproofs"]
 [[bench]]
 name = "range_proof"
 harness = false
+required-features = ["avx2_backend"]
 
 [[bench]]
 name = "generators"
@@ -61,4 +65,4 @@ harness = false
 [[bench]]
 name = "r1cs"
 harness = false
-required-features = ["yoloproofs"]
+required-features = ["yoloproofs", "avx2_backend"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 FEATURES := yoloproofs
 
 doc:
-	cargo rustdoc --features "$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html
+	cargo rustdoc --features "docs,$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html
 
 doc-internal:
-	cargo rustdoc --features "$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html --document-private-items
+	cargo rustdoc --features "docs,$(FEATURES)" -- --html-in-header docs/assets/rustdoc-include-katex-header.html --document-private-items
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2019-07-31
+nightly


### PR DESCRIPTION
Added support for stable rust as per https://github.com/dalek-cryptography/bulletproofs/pull/318 due to `clear_on_drop` issues