### PR TITLE
add ci 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+  pull_request:
+    types: [opened]
+
+name: Test
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2020-06-10
+          components: clippy, rustfmt
+          override: true
+
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      # run cargo bench with a filter that matches no benchmarks.
+      # this ensures the benchmarks build but doesn't run them on the CI server.
+      - name: cargo bench build
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: EXTRA_FLAGS='"DONTRUNBENCHMARKS"'


### PR DESCRIPTION
Add github actions to catch `cargo fmt`, as well as run `cargo test` and ensure that `cargo bench` builds ( to match with the upstream travis ci ) 