### PR TITLE
chore: replace clear_on_drop with zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "3", default-features = false }
-clear_on_drop = { version = "=0.2.4", default-features = false }
+zeroize = "1.5.3"
 
 [dev-dependencies]
 hex = "0.3"
@@ -43,7 +43,7 @@ simd_backend = ["curve25519-dalek/simd_backend"]
 avx2_backend = ["simd_backend"] # deprecated alias for simd_backend
 yoloproofs = []
 std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
+nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly"]
 docs = ["nightly"]
 
 

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -1,12 +1,12 @@
 #![allow(non_snake_case)]
 
-use clear_on_drop::clear::Clear;
 use core::borrow::BorrowMut;
 use core::mem;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::{Identity, MultiscalarMul};
 use merlin::Transcript;
+use zeroize::Zeroize;
 
 use super::{
     ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,
@@ -74,24 +74,18 @@ pub struct RandomizingProver<'g, T: BorrowMut<Transcript>> {
 /// Overwrite secrets with null bytes when they go out of scope.
 impl Drop for Secrets {
     fn drop(&mut self) {
-        self.v.clear();
-        self.v_blinding.clear();
+        self.v.zeroize();
+        self.v_blinding.zeroize();
 
-        // Important: due to how ClearOnDrop auto-implements InitializableFromZeroed
-        // for T: Default, calling .clear() on Vec compiles, but does not
-        // clear the content. Instead, it only clears the Vec's header.
-        // Clearing the underlying buffer item-by-item will do the job, but will
-        // keep the header as-is, which is fine since the header does not contain secrets.
         for e in self.a_L.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.a_R.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.a_O.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
-        // XXX use ClearOnDrop instead of doing the above
     }
 }
 
@@ -697,16 +691,13 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
             r_vec,
         );
 
-        // We do not yet have a ClearOnDrop wrapper for Vec<Scalar>.
-        // When PR 202 [1] is merged, we can simply wrap s_L and s_R at the point of creation.
-        // [1] https://github.com/dalek-cryptography/curve25519-dalek/pull/202
         for scalar in s_L1
             .iter_mut()
             .chain(s_L2.iter_mut())
             .chain(s_R1.iter_mut())
             .chain(s_R2.iter_mut())
         {
-            scalar.clear();
+            scalar.zeroize();
         }
         let proof = R1CSProof {
             A_I1,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -744,6 +744,7 @@ impl RangeProof {
 
         use crate::util::read32;
 
+        #[allow(clippy::erasing_op)]
         let A = CompressedRistretto(read32(&slice[0 * 32..]));
         let S = CompressedRistretto(read32(&slice[1 * 32..]));
         let T_1 = CompressedRistretto(read32(&slice[2 * 32..]));

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -13,12 +13,12 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use clear_on_drop::clear::Clear;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 use rand_core::{CryptoRng, RngCore};
+use zeroize::Zeroize;
 
 use crate::errors::MPCError;
 use crate::generators::{BulletproofGens, PedersenGens};
@@ -194,8 +194,8 @@ impl<'a> PartyAwaitingPosition<'a> {
 /// Overwrite secrets with null bytes when they go out of scope.
 impl<'a> Drop for PartyAwaitingPosition<'a> {
     fn drop(&mut self) {
-        self.v.clear();
-        self.v_blinding.clear();
+        self.v.zeroize();
+        self.v_blinding.zeroize();
     }
 }
 
@@ -297,21 +297,16 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
 /// Overwrite secrets with null bytes when they go out of scope.
 impl<'a> Drop for PartyAwaitingBitChallenge<'a> {
     fn drop(&mut self) {
-        self.v.clear();
-        self.v_blinding.clear();
-        self.a_blinding.clear();
-        self.s_blinding.clear();
+        self.v.zeroize();
+        self.v_blinding.zeroize();
+        self.a_blinding.zeroize();
+        self.s_blinding.zeroize();
 
-        // Important: due to how ClearOnDrop auto-implements InitializableFromZeroed
-        // for T: Default, calling .clear() on Vec compiles, but does not
-        // clear the content. Instead, it only clears the Vec's header.
-        // Clearing the underlying buffer item-by-item will do the job, but will
-        // keep the header as-is, which is fine since the header does not contain secrets.
         for e in self.s_L.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.s_R.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
     }
 }
@@ -365,11 +360,11 @@ impl PartyAwaitingPolyChallenge {
 /// Overwrite secrets with null bytes when they go out of scope.
 impl Drop for PartyAwaitingPolyChallenge {
     fn drop(&mut self) {
-        self.v_blinding.clear();
-        self.a_blinding.clear();
-        self.s_blinding.clear();
-        self.t_1_blinding.clear();
-        self.t_2_blinding.clear();
+        self.v_blinding.zeroize();
+        self.a_blinding.zeroize();
+        self.s_blinding.zeroize();
+        self.t_1_blinding.zeroize();
+        self.t_2_blinding.zeroize();
 
         // Note: polynomials r_poly, l_poly and t_poly
         // are cleared within their own Drop impls.

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,8 +5,8 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
-use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;
+use zeroize::Zeroize;
 
 use crate::inner_product_proof::inner_product;
 use std::cmp::{max, min};
@@ -171,19 +171,19 @@ impl Poly6 {
 impl Drop for VecPoly1 {
     fn drop(&mut self) {
         for e in self.0.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.1.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
     }
 }
 
 impl Drop for Poly2 {
     fn drop(&mut self) {
-        self.0.clear();
-        self.1.clear();
-        self.2.clear();
+        self.0.zeroize();
+        self.1.zeroize();
+        self.2.zeroize();
     }
 }
 
@@ -191,16 +191,16 @@ impl Drop for Poly2 {
 impl Drop for VecPoly3 {
     fn drop(&mut self) {
         for e in self.0.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.1.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.2.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
         for e in self.3.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
     }
 }
@@ -208,12 +208,12 @@ impl Drop for VecPoly3 {
 #[cfg(feature = "yoloproofs")]
 impl Drop for Poly6 {
     fn drop(&mut self) {
-        self.t1.clear();
-        self.t2.clear();
-        self.t3.clear();
-        self.t4.clear();
-        self.t5.clear();
-        self.t6.clear();
+        self.t1.zeroize();
+        self.t2.zeroize();
+        self.t3.zeroize();
+        self.t4.zeroize();
+        self.t5.zeroize();
+        self.t6.zeroize();
     }
 }
 
@@ -422,11 +422,11 @@ mod tests {
     }
 
     #[test]
-    fn vec_of_scalars_clear_on_drop() {
+    fn vec_of_scalars_zeroize() {
         let mut v = vec![Scalar::from(24u64), Scalar::from(42u64)];
 
         for e in v.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
 
         fn flat_slice<T>(x: &[T]) -> &[u8] {
@@ -442,16 +442,16 @@ mod tests {
     }
 
     #[test]
-    fn tuple_of_scalars_clear_on_drop() {
+    fn tuple_of_scalars_zeroize() {
         let mut v = Poly2(
             Scalar::from(24u64),
             Scalar::from(42u64),
             Scalar::from(255u64),
         );
 
-        v.0.clear();
-        v.1.clear();
-        v.2.clear();
+        v.0.zeroize();
+        v.1.zeroize();
+        v.2.zeroize();
 
         fn as_bytes<T>(x: &T) -> &[u8] {
             use core::mem;


### PR DESCRIPTION
clear_on_drop does not compile to wasm target, and zeroize is more actively maintained